### PR TITLE
Create ja_jp.json

### DIFF
--- a/src/main/resources/assets/goblintraders/lang/ja_jp.json
+++ b/src/main/resources/assets/goblintraders/lang/ja_jp.json
@@ -1,0 +1,9 @@
+{
+    "entity.goblintraders.goblin_trader": "ゴブリン行商人",
+    "entity.goblintraders.vein_goblin_trader": "溶岩ゴブリン行商人",
+    "subtitle.goblintraders.goblin_trader.annoyed_grunt": "ゴブリンのうめき声",
+    "subtitle.goblintraders.goblin_trader.idle_grunt": "ゴブリンの声",
+    "item.goblintraders.goblin_trader_spawn_egg": "ゴブリン行商人のスポーンエッグ",
+    "item.goblintraders.vein_goblin_trader_spawn_egg": "溶岩ゴブリン行商人のスポーンエッグ",
+    "stat.goblintraders.trade_with_goblin": "ゴブリンと取引した回数",
+}


### PR DESCRIPTION
Japanese translation. Some word-for-word translation doesn't fit in Japanese, I used the following words:
"Vein Goblin" to "溶岩ゴブリン" (Lava Goblin)
"Annoyed Grunt" to "ゴブリンのうめき声" (Goblin's groaning sound or voice)
"Idle Grunt" to "ゴブリンの声" (Goblin's sound or voice)